### PR TITLE
block group falling multiple spaces at once fix

### DIFF
--- a/source/Block.cpp
+++ b/source/Block.cpp
@@ -8,6 +8,7 @@ Block::Block() {
   done = false;
   done_sub = false;
   unsetlock = false;
+  just_landed = false;
 
   destroycount = 0;
 

--- a/source/Block.h
+++ b/source/Block.h
@@ -35,6 +35,8 @@ class Block {
 
   bool unsetlock;
 
+  bool just_landed;
+
   int destroycount;  // for X block
 
   int shape;  // for soft blocks

--- a/source/Stage.cpp
+++ b/source/Stage.cpp
@@ -996,7 +996,8 @@ void Stage::erase_check_recursive(int x, int y, int type, int *answer,
   if (p->state == Block::blockState::BLOCKSTATE_FALLING) return;
   (*number)++;
   //	if(p->state==BLOCKSTATE_EXTINGUISHED||p->state==BLOCKSTATE_EXTINGUISHING)(*answer)=1;
-  if (p->state == Block::blockState::BLOCKSTATE_FALLFINISHED) (*answer) = 1;
+  if (p->just_landed) (*answer) = 1;
+  p->just_landed = false;
 
   if (x > 0) erase_check_recursive(x - 1, y, type, answer, number);
   if (x < GAME_STAGE_WIDTH - 1)
@@ -1507,6 +1508,8 @@ void Stage::unsetprefall(int x, int y, int type) {
   if (p->state == Block::blockState::BLOCKSTATE_EXTINGUISHED ||
       p->state == Block::blockState::BLOCKSTATE_EXTINGUISHING)
     return;
+  if (p->state == Block::blockState::BLOCKSTATE_FALLFINISHED)
+    p->just_landed = true;
   p->state = Block::blockState::BLOCKSTATE_NONE;
   p->lefttime = PREFALLTIME;
   p->unsetlock = true;


### PR DESCRIPTION
Previously, if a block group of size > 3 had _n_ empty tiles below it, it would fall down one tile, then immediately extinguish itself. This change should allow that group to fall down all _n_ tiles and THEN extinguish.

This does not address the case where a block group falls down one tile and is above another group that is in the process of extinguishing - in that case the group will still extinguish itself immediately instead of waiting for the below group to finish extinguishing and continue falling.

This is specific code is untested as I'm unable to find the right SDL files to build this codebase with, but it has been tested in a separate test project and appears to work as described.